### PR TITLE
Make h5py handler lazy.

### DIFF
--- a/area_detector_handlers/handlers.py
+++ b/area_detector_handlers/handlers.py
@@ -112,7 +112,7 @@ class HDF5DatasetSliceHandlerPureNumpy(HandlerBase):
 
     def __call__(self, point_number):
         # Don't read out the dataset until it is requested for the first time.
-        if not self._dataset:
+        if self._dataset is None:
             self._dataset = self._file[self._key]
         start = point_number * self._fpp
         stop = (point_number + 1) * self._fpp
@@ -135,11 +135,11 @@ class HDF5DatasetSliceHandler(HDF5DatasetSliceHandlerPureNumpy):
 
     def __call__(self, point_number):
         # Don't read out the dataset until it is requested for the first time.
-        if not self._dataset:
-            self._dataset = self._file[self._key]
+        if self._dataset is None:
+            self._dataset = dask.array.from_array(self._file[self._key])
         start = point_number * self._fpp
         stop = (point_number + 1) * self._fpp
-        return dask.array.from_array(self._dataset)[start:stop]
+        return self._dataset[start:stop]
 
 
 class AreaDetectorHDF5Handler(HDF5DatasetSliceHandler):

--- a/area_detector_handlers/handlers.py
+++ b/area_detector_handlers/handlers.py
@@ -1,7 +1,7 @@
 import logging
 import os.path
 
-
+import dask.array
 import h5py
 import numpy as np
 import tifffile
@@ -79,7 +79,7 @@ class AreaDetectorTiffHandler(HandlerBase):
         return ret
 
 
-class HDF5DatasetSliceHandler(HandlerBase):
+class HDF5DatasetSliceHandlerPureNumpy(HandlerBase):
     """
     Handler for data stored in one Dataset of an HDF5 file.
 
@@ -95,7 +95,7 @@ class HDF5DatasetSliceHandler(HandlerBase):
         Open the hdf5 file in SWMR read mode. Only used when mode = 'r'.
         Default is False.
     """
-
+    return_type = {'delayed': False}
     specs = set()
 
     def __init__(self, filename, key, frame_per_point=1):
@@ -128,6 +128,18 @@ class HDF5DatasetSliceHandler(HandlerBase):
         super().close()
         self._file.close()
         self._file = None
+
+
+class HDF5DatasetSliceHandler(HDF5DatasetSliceHandlerPureNumpy):
+    return_type = {'delayed': True}
+
+    def __call__(self, point_number):
+        # Don't read out the dataset until it is requested for the first time.
+        if not self._dataset:
+            self._dataset = self._file[self._key]
+        start = point_number * self._fpp
+        stop = (point_number + 1) * self._fpp
+        return dask.array.from_array(self._dataset)[start:stop]
 
 
 class AreaDetectorHDF5Handler(HDF5DatasetSliceHandler):

--- a/area_detector_handlers/tests/conftest.py
+++ b/area_detector_handlers/tests/conftest.py
@@ -54,6 +54,32 @@ def xs3file(request):
 
 
 @pytest.fixture(scope="module", params=[1, 5])
+def hdf5_files(request):
+    N_rows = 13
+    N_cols = 27
+    N_points = 7
+    fpp = request.param
+    f_dir = TemporaryDirectory()
+    fname = f"adh_{fpp}_test.h5"
+    full_path = str(Path(f_dir.name, fname))
+
+    data = np.concatenate([
+        np.ones((fpp, N_rows, N_cols)) * pt for pt in range(N_points)])
+    with h5py.File(full_path) as file:
+        file.create_dataset('entry/data/data', data=data)
+
+    def finalize():
+        f_dir.cleanup()
+
+    request.addfinalizer(finalize)
+
+    return (
+        (full_path, dict(frame_per_point=fpp)),
+        (N_rows, N_cols, N_points, fpp),
+    )
+
+
+@pytest.fixture(scope="module", params=[1, 5])
 def tiff_files(request):
     N_rows = 13
     N_cols = 27

--- a/area_detector_handlers/tests/test_hdf5.py
+++ b/area_detector_handlers/tests/test_hdf5.py
@@ -1,0 +1,13 @@
+from area_detector_handlers.tests.conftest import select_handler
+import numpy as np
+
+
+@select_handler("AD_HDF5")
+def test_hdf5(hdf5_files, handler):
+    (rpath, kwargs), (N_rows, N_cols, N_points, fpp) = hdf5_files
+    expected_shape = (fpp, N_rows, N_cols)
+    with handler(rpath, **kwargs) as h:
+        for frame in range(N_points):
+            d = h(point_number=frame)
+            assert d.shape == expected_shape
+            assert np.all(d == frame)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+dask[array]
 h5py
 tifffile


### PR DESCRIPTION
We previously relied on PIMS do this. To avoid some of the assumptions baked into PIMS, I think that (at least for now) we need format-specific solutions. I am starting with h5py and ignoring TIFF because TIFFs tend not to be too large for memory, so it is not as critical to make them lazy.

The other h5py handler(s) should be updated similarly before this is merged.