### PR TITLE
Reraise h5py KeyError as IOError.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ install:
   - pip install .
   # Install extra requirements for running tests and building docs.
   - pip install -r requirements-dev.txt
+  # Avoid incompatibility issues between third-party dependencies and numpy.
+  - pip install --upgrade numpy
 
 script:
   - coverage run -m pytest  # Run the tests and check for test coverage.

--- a/area_detector_handlers/handlers.py
+++ b/area_detector_handlers/handlers.py
@@ -81,6 +81,12 @@ class AreaDetectorTiffHandler(HandlerBase):
         return ret
 
 
+H5PY_KEYERROR_IOERROR_MSG = (
+    "h5py raised a KeyError but this can sometimes actually "
+    "mean an IOError. Raising as an IOError so that Filler will "
+    "retry. (After several retries with backoff Filler gives up.)")
+
+
 class HDF5DatasetSliceHandlerPureNumpy(HandlerBase):
     """
     Handler for data stored in one Dataset of an HDF5 file.
@@ -118,11 +124,7 @@ class HDF5DatasetSliceHandlerPureNumpy(HandlerBase):
             try:
                 self._dataset = self._file[self._key]
             except KeyError as error:
-                raise IOError(
-                    "h5py raised a KeyError but this can sometimes actually "
-                    "mean an IOError. Raise as an IOError so that Filler will "
-                    "retry. (After several retries with backoff Filler "
-                    "gives up.)") from error
+                raise IOError(H5PY_KEYERROR_IOERROR_MSG) from error
         start = point_number * self._fpp
         stop = (point_number + 1) * self._fpp
         return self._dataset[start:stop]
@@ -148,11 +150,7 @@ class HDF5DatasetSliceHandler(HDF5DatasetSliceHandlerPureNumpy):
             try:
                 self._dataset = dask.array.from_array(self._file[self._key])
             except KeyError as error:
-                raise IOError(
-                    "h5py raised a KeyError but this can sometimes actually "
-                    "mean an IOError. Raise as an IOError so that Filler will "
-                    "retry. (After several retries with backoff Filler "
-                    "gives up.)") from error
+                raise IOError(H5PY_KEYERROR_IOERROR_MSG) from error
         start = point_number * self._fpp
         stop = (point_number + 1) * self._fpp
         return self._dataset[start:stop]
@@ -246,20 +244,12 @@ class AreaDetectorHDF5TimestampHandler(HandlerBase):
             try:
                 self._dataset1 = self._file[self._key[0]]
             except KeyError as error:
-                raise IOError(
-                    "h5py raised a KeyError but this can sometimes actually "
-                    "mean an IOError. Raise as an IOError so that Filler will "
-                    "retry. (After several retries with backoff Filler "
-                    "gives up.)") from error
+                raise IOError(H5PY_KEYERROR_IOERROR_MSG) from error
         if not self._dataset2:
             try:
                 self._dataset2 = self._file[self._key[1]]
             except KeyError as error:
-                raise IOError(
-                    "h5py raised a KeyError but this can sometimes actually "
-                    "mean an IOError. Raise as an IOError so that Filler will "
-                    "retry. (After several retries with backoff Filler "
-                    "gives up.)") from error
+                raise IOError(H5PY_KEYERROR_IOERROR_MSG) from error
         start, stop = point_number * self._fpp, (point_number + 1) * self._fpp
         rtn = self._dataset1[start:stop].squeeze()
         rtn = rtn + (self._dataset2[start:stop].squeeze() * 1e-9)

--- a/area_detector_handlers/tests/conftest.py
+++ b/area_detector_handlers/tests/conftest.py
@@ -98,7 +98,7 @@ def hdf5_files(request):
 
     data = np.concatenate([
         np.ones((fpp, N_rows, N_cols)) * pt for pt in range(N_points)])
-    with h5py.File(full_path) as file:
+    with h5py.File(full_path, "w") as file:
         file.create_dataset('entry/data/data', data=data)
 
     def finalize():


### PR DESCRIPTION
Per h5py/HDF5 expert @tacaswell, it is difficult to h5py to handle
all HDF5 errors and reraise them correctly because they are not treated
as stable.

We encountered a situation at FXI where a file was not ready to be read,
raised a KeyError, and caused the Filler to give up. We want the Filler
to engage is retry-with-backoff-before-giving-up behavior.

We think it is correct that Filler only catches IOError in its backoff
loop. Other exceptions could indicate real errors that should be
reported immediately without waiting for a retry loop. It is the job of
the handlers to ensure that they raise IOError when the underlying I/O
library may be encountering an I/O issue that could be resolved by
waiting and retrying.