### PR TITLE
Migrate remaining handlers from profiles

### DIFF
--- a/area_detector_handlers/_xspress3.py
+++ b/area_detector_handlers/_xspress3.py
@@ -7,8 +7,7 @@ logger = logging.getLogger(__name__)
 
 
 class BulkXSPRESS(HandlerBase):
-    specs = {"XSP3_FLY"}
-    HANDLER_NAME = "XSP3_FLY"
+    specs = {'XSP3_FLY', 'XPS3_FLY'} | HandlerBase.specs
     BASE_PATH = "entry/instrument/detector/"
 
     def __init__(self, resource_fn):

--- a/area_detector_handlers/_xspress3.py
+++ b/area_detector_handlers/_xspress3.py
@@ -7,7 +7,14 @@ logger = logging.getLogger(__name__)
 
 
 class BulkXSPRESS(HandlerBase):
-    specs = {'XSP3_FLY', 'XPS3_FLY', 'DEXELA_FLY_V1', 'MERLIN_FLY_STREAM_V1', 'MERLIN_FLY'} | HandlerBase.specs
+    specs = {
+        'XSP3_FLY',
+        'XPS3_FLY',                 # SRX, TES
+        'DEXELA_FLY_V1',            # SRX
+        'MERLIN_FLY_STREAM_V1',     # SRX
+        'MERLIN_FLY'                # SRX
+    }
+
     BASE_PATH = "entry/instrument/detector/"
 
     def __init__(self, resource_fn):
@@ -31,7 +38,7 @@ XS3_XRF_DATA_KEY = "entry/instrument/detector/data"
 
 
 class Xspress3HDF5Handler(HandlerBase):
-    specs = {"XSP3"} | HandlerBase.specs
+    specs = {"XSP3"}
     HANDLER_NAME = "XSP3"
 
     def __init__(self, filename, key=XS3_XRF_DATA_KEY):

--- a/area_detector_handlers/_xspress3.py
+++ b/area_detector_handlers/_xspress3.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 
 class BulkXSPRESS(HandlerBase):
-    specs = {'XSP3_FLY', 'XPS3_FLY'} | HandlerBase.specs
+    specs = {'XSP3_FLY', 'XPS3_FLY', 'DEXELA_FLY_V1'} | HandlerBase.specs
     BASE_PATH = "entry/instrument/detector/"
 
     def __init__(self, resource_fn):

--- a/area_detector_handlers/_xspress3.py
+++ b/area_detector_handlers/_xspress3.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 
 class BulkXSPRESS(HandlerBase):
-    specs = {'XSP3_FLY', 'XPS3_FLY', 'DEXELA_FLY_V1'} | HandlerBase.specs
+    specs = {'XSP3_FLY', 'XPS3_FLY', 'DEXELA_FLY_V1', 'MERLIN_FLY_STREAM_V1', 'MERLIN_FLY'} | HandlerBase.specs
     BASE_PATH = "entry/instrument/detector/"
 
     def __init__(self, resource_fn):

--- a/area_detector_handlers/eiger.py
+++ b/area_detector_handlers/eiger.py
@@ -25,7 +25,12 @@ class EigerHandler(HandlerBase):
         'count_time': 'entry/instrument/detector/count_time',
         'pixel_mask': 'entry/instrument/detector/detectorSpecific/pixel_mask',
     }
-    specs = {'AD_EIGER2', 'AD_EIGER', 'AD_EIGER_SLICE'}
+
+    specs = {
+        'AD_EIGER2',        # CHX, ISR
+        'AD_EIGER',         # CHX
+        'AD_EIGER_SLICE',   # CHX
+    }
 
     def __init__(self, fpath, images_per_file=None, frame_per_point=None):
         '''

--- a/area_detector_handlers/eiger.py
+++ b/area_detector_handlers/eiger.py
@@ -25,7 +25,7 @@ class EigerHandler(HandlerBase):
         'count_time': 'entry/instrument/detector/count_time',
         'pixel_mask': 'entry/instrument/detector/detectorSpecific/pixel_mask',
     }
-    specs = {'AD_EIGER2', 'AD_EIGER'}
+    specs = {'AD_EIGER2', 'AD_EIGER', 'AD_EIGER_SLICE'}
 
     def __init__(self, fpath, images_per_file=None, frame_per_point=None):
         '''

--- a/area_detector_handlers/handlers.py
+++ b/area_detector_handlers/handlers.py
@@ -621,3 +621,32 @@ class SpecsHDF5SingleHandlerDataFrame(HandlerBase):
         for d_kw in datum_kwargs:
             ret.extend(self._fnames_for_point(**d_kw))
         return ret
+
+
+class TimepixHDF5Handler(HDF5DatasetSliceHandler):
+    """
+    Handler for the 'AD_HDF5' spec used by Area Detectors.
+    In this spec, the key (i.e., HDF5 dataset path) is always
+    '/entry/detector/data'.
+    Parameters
+    ----------
+    filename : string
+        path to HDF5 file
+    frame_per_point : integer, optional
+        number of frames to return as one datum, default 1
+    """
+    _handler_name = 'TPX_HDF5'
+    specs = {_handler_name}
+
+    # Ported from
+    #
+    # https://github.com/NSLS-II-HXN/hxntools/blob/16bcf9b16e962e2ba8bda6bc7dc56694482c3af3/
+    # hxntools/handlers/timepix.py#L56-L77
+    #
+    # TODO this is only different due to the hardcoded key being different?
+    hardcoded_key = '/entry/instrument/detector/data'
+
+    def __init__(self, filename, frame_per_point=1):
+        super(TimepixHDF5Handler, self).__init__(
+                filename=filename, key=self.hardcoded_key,
+                frame_per_point=frame_per_point)

--- a/area_detector_handlers/handlers.py
+++ b/area_detector_handlers/handlers.py
@@ -607,11 +607,11 @@ class SpecsHDF5SingleHandlerDataFrame(HandlerBase):
             with h5py.File(fn, 'r') as f:
                 dataframe = pd.DataFrame(np.array(f[self._key][:]).transpose(),
                                          columns=self._column_names)
-                start_energy=f['/entry/instrument/NDAttributes/StartEnergy'][0]
-                stop_energy=f['/entry/instrument/NDAttributes/StopEnergy'][0]
-                step_energy=f['/entry/instrument/NDAttributes/StepEnergy'][0]
-                kinetic_energy = temp=np.append(
-                    np.arange(start_energy, stop_energy,step_energy), stop_energy)
+                start_energy = f['/entry/instrument/NDAttributes/StartEnergy'][0]
+                stop_energy = f['/entry/instrument/NDAttributes/StopEnergy'][0]
+                step_energy = f['/entry/instrument/NDAttributes/StepEnergy'][0]
+                kinetic_energy = np.append(
+                    np.arange(start_energy, stop_energy, step_energy), stop_energy)
                 dataframe['kinetic_energy'] = kinetic_energy
             ret.append(dataframe)
         return ret

--- a/area_detector_handlers/handlers.py
+++ b/area_detector_handlers/handlers.py
@@ -602,7 +602,6 @@ class SpecsHDF5SingleHandlerDataFrame(HandlerBase):
 
     def __call__(self, point_number):
         ret = []
-        import h5py
         for fn in self._fnames_for_point(point_number):
             with h5py.File(fn, 'r') as f:
                 dataframe = pd.DataFrame(np.array(f[self._key][:]).transpose(),

--- a/area_detector_handlers/handlers.py
+++ b/area_detector_handlers/handlers.py
@@ -6,6 +6,7 @@ import dask
 import dask.array
 import h5py
 import numpy as np
+import pandas as pd
 import tifffile
 
 from . import HandlerBase
@@ -556,3 +557,67 @@ class AreaDetectorHDF5SingleHandler(HDF5SingleHandler):
         super(AreaDetectorHDF5SingleHandler, self).__init__(
             fpath=fpath, template=template, filename=filename,
             key=hardcoded_key, frame_per_point=frame_per_point)
+
+
+class SpecsHDF5SingleHandlerDataFrame(HandlerBase):
+    """Handler for hdf5 data stored 1 image per file and returned as a
+-    Pandas.DataFrame.
+
+    This will work with all hdf5 files that are a mxn arrays and the data is
+    'table like' where m is the number of columns and n is the number of rows.
+
+    Parameters
+    ----------
+    fpath : string
+        filepath
+    template : string
+        filename template string.
+    filename : string
+        filename
+    key : string
+        the 'path' inside the file to the data set.
+    column_names : list[str]
+        The column names of the table
+    frame_per_point : float
+        the number of frames per point.
+    """
+    specs = {'SPECS_HDF5_SINGLE_DATAFRAME'}  # Used by IOS
+
+    def __init__(self, fpath, template, filename, key='/entry/data/data',
+                 column_names=None, frame_per_point=1):
+        # I have included defaults for `key` and 'column_names' for back
+        # compatibility with existing files at SIX.
+        self._path = os.path.join(fpath, '')
+        self._fpp = frame_per_point
+        self._template = template
+        self._filename = filename
+        self._key = key
+        self._column_names = column_names
+
+    def _fnames_for_point(self, point_number):
+        start = int(point_number * self._fpp)
+        stop = int((point_number + 1) * self._fpp)
+        for j in range(start, stop):
+            yield self._template % (self._path, self._filename, j)
+
+    def __call__(self, point_number):
+        ret = []
+        import h5py
+        for fn in self._fnames_for_point(point_number):
+            with h5py.File(fn, 'r') as f:
+                dataframe = pd.DataFrame(np.array(f[self._key][:]).transpose(),
+                                         columns=self._column_names)
+                start_energy=f['/entry/instrument/NDAttributes/StartEnergy'][0]
+                stop_energy=f['/entry/instrument/NDAttributes/StopEnergy'][0]
+                step_energy=f['/entry/instrument/NDAttributes/StepEnergy'][0]
+                kinetic_energy = temp=np.append(
+                    np.arange(start_energy, stop_energy,step_energy), stop_energy)
+                dataframe['kinetic_energy'] = kinetic_energy
+            ret.append(dataframe)
+        return ret
+
+    def get_file_list(self, datum_kwargs):
+        ret = []
+        for d_kw in datum_kwargs:
+            ret.extend(self._fnames_for_point(**d_kw))
+        return ret

--- a/area_detector_handlers/handlers.py
+++ b/area_detector_handlers/handlers.py
@@ -487,3 +487,72 @@ class IMMHandler(HandlerBase):
 
     def get_file_list(self, datum_kwargs_gen):
         return [self.filename]
+
+
+class HDF5SingleHandler(HandlerBase):
+    """
+    Handler for hdf5 data stored 1 image per file.
+
+    Parameters
+    ----------
+    fpath : string
+        filepath
+    template : string
+        filename template string.
+    filename : string
+        filename
+    key : string
+        the 'path' inside the file to the data set.
+    frame_per_point : float
+        the number of frames per point.
+    """
+    specs = {'AD_HDF5_SINGLE'}  # Used by SIX
+
+    def __init__(self, fpath, template, filename, key, frame_per_point=1):
+        self._path = os.path.join(fpath, '')
+        self._fpp = frame_per_point
+        self._template = template
+        self._filename = filename
+        self._key = key
+
+    def _fnames_for_point(self, point_number):
+        start = int(point_number * self._fpp)
+        stop = int((point_number + 1) * self._fpp)
+        for j in range(start, stop):
+            yield self._template % (self._path, self._filename, j)
+
+    def __call__(self, point_number):
+        ret = []
+        for fn in self._fnames_for_point(point_number):
+            f = h5py.File(fn, 'r')
+            data = f[self._key]
+            ret.append(data)
+        return ret
+
+    def get_file_list(self, datum_kwargs):
+        ret = []
+        for d_kw in datum_kwargs:
+            ret.extend(self._fnames_for_point(**d_kw))
+        return ret
+
+
+class AreaDetectorHDF5SingleHandler(HDF5SingleHandler):
+    """
+    Handler for hdf5 data stored 1 image per file by areadetector
+
+    Parameters
+    ----------
+    fpath : string
+        filepath
+    template : string
+        filename template string.
+    filename : string
+        filename
+    frame_per_point : float
+        the number of frames per point.
+    """
+    def __init__(self, fpath, template, filename, frame_per_point=1):
+        hardcoded_key = '/entry/data/data'
+        super(AreaDetectorHDF5SingleHandler, self).__init__(
+            fpath=fpath, template=template, filename=filename,
+            key=hardcoded_key, frame_per_point=frame_per_point)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 dask[array]
 h5py
+pandas
 tifffile

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
             "AD_CBF = area_detector_handlers.handlers:PilatusCBFHandler",
             "XSP3_FLY = area_detector_handlers.handlers:BulkXSPRESS",
             "XPS3_FLY = area_detector_handlers.handlers:BulkXSPRESS",
+            "DEXELA_FLY_V1 = area_detector_handlers.handlers:BulkXSPRESS",
             "IMM = area_detector_handlers.handlers:IMMHandler",
         ]
     },

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
             "XSP3 = area_detector_handlers.handlers:Xspress3HDF5Handler",
             "AD_CBF = area_detector_handlers.handlers:PilatusCBFHandler",
             "XSP3_FLY = area_detector_handlers.handlers:BulkXSPRESS",
+            "XPS3_FLY = area_detector_handlers.handlers:BulkXSPRESS",
             "IMM = area_detector_handlers.handlers:IMMHandler",
         ]
     },

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,8 @@ setup(
             "XSP3_FLY = area_detector_handlers.handlers:BulkXSPRESS",
             "XPS3_FLY = area_detector_handlers.handlers:BulkXSPRESS",
             "DEXELA_FLY_V1 = area_detector_handlers.handlers:BulkXSPRESS",
+            "MERLIN_FLY_STREAM_V1 = area_detector_handlers.handlers:BulkXSPRESS",
+            "MERLIN_FLY = area_detector_handlers.handlers:BulkXSPRESS",
             "IMM = area_detector_handlers.handlers:IMMHandler",
         ]
     },

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
             "AD_TIFF = area_detector_handlers.handlers:AreaDetectorTiffHandler",
             "AD_EIGER = area_detector_handlers.eiger:EigerHandler",
             "AD_EIGER2 = area_detector_handlers.eiger:EigerHandler",
+            "AD_EIGER_SLICE = area_detector_handlers.eiger:EigerHandler",
             "AD_HDF5 = area_detector_handlers.handlers:AreaDetectorHDF5Handler",
             "AD_HDF5_SWMR = area_detector_handlers.handlers:AreaDetectorHDF5SWMRHandler",
             "AD_HDF5_TS = area_detector_handlers.handlers:AreaDetectorHDF5TimestampHandler",

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
             "AD_HDF5_SWMR = area_detector_handlers.handlers:AreaDetectorHDF5SWMRHandler",
             "AD_HDF5_TS = area_detector_handlers.handlers:AreaDetectorHDF5TimestampHandler",
             "AD_HDF5_SWMR_TS = area_detector_handlers.handlers:AreaDetectorHDF5SWMRTimestampHandler",
+            "AD_HDF5_SINGLE = area_detector_handlers.handlers:AreaDetectorHDF5SingleHandler",
             "XSP3 = area_detector_handlers.handlers:Xspress3HDF5Handler",
             "AD_CBF = area_detector_handlers.handlers:PilatusCBFHandler",
             "XSP3_FLY = area_detector_handlers.handlers:BulkXSPRESS",

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
             "AD_HDF5_TS = area_detector_handlers.handlers:AreaDetectorHDF5TimestampHandler",
             "AD_HDF5_SWMR_TS = area_detector_handlers.handlers:AreaDetectorHDF5SWMRTimestampHandler",
             "AD_HDF5_SINGLE = area_detector_handlers.handlers:AreaDetectorHDF5SingleHandler",
+            "SPECS_HDF5_SINGLE_DATAFRAME = area_detector_handlers.handlers:SpecsHDF5SingleHandlerDataFrame",
             "XSP3 = area_detector_handlers.handlers:Xspress3HDF5Handler",
             "AD_CBF = area_detector_handlers.handlers:PilatusCBFHandler",
             "XSP3_FLY = area_detector_handlers.handlers:BulkXSPRESS",

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
             "AD_HDF5_SINGLE = area_detector_handlers.handlers:AreaDetectorHDF5SingleHandler",
             "SPECS_HDF5_SINGLE_DATAFRAME = area_detector_handlers.handlers:SpecsHDF5SingleHandlerDataFrame",
             "XSP3 = area_detector_handlers.handlers:Xspress3HDF5Handler",
+            "TPX_HDF5 = area_detector_handlers.handlers:TimepixHDF5Handler",
             "AD_CBF = area_detector_handlers.handlers:PilatusCBFHandler",
             "XSP3_FLY = area_detector_handlers.handlers:BulkXSPRESS",
             "XPS3_FLY = area_detector_handlers.handlers:BulkXSPRESS",


### PR DESCRIPTION
This PR is to move any remaining areadetector handlers from beamline profiles to here.

Related: https://github.com/bluesky/databroker/issues/533