### PR TITLE
remove .squeeze() for databroker v2 compat

### DIFF
--- a/area_detector_handlers/handlers.py
+++ b/area_detector_handlers/handlers.py
@@ -73,7 +73,7 @@ class AreaDetectorTiffHandler(HandlerBase):
         for fn in self._fnames_for_point(point_number):
             with tifffile.TiffFile(fn) as tif:
                 ret.append(tif.asarray())
-        return np.array(ret).squeeze()
+        return np.array(ret)
 
     def get_file_list(self, datum_kwargs):
         ret = []

--- a/area_detector_handlers/tests/test_tiff.py
+++ b/area_detector_handlers/tests/test_tiff.py
@@ -5,10 +5,7 @@ import numpy as np
 @select_handler("AD_TIFF")
 def test_tiff(tiff_files, handler):
     (rpath, kwargs), (N_rows, N_cols, N_points, fpp) = tiff_files
-    if fpp == 1:
-        expected_shape = (N_rows, N_cols)
-    else:
-        expected_shape = (fpp, N_rows, N_cols)
+    expected_shape = (fpp, N_rows, N_cols)
     with handler(rpath, **kwargs) as h:
         for frame in range(N_points):
             d = h(point_number=frame)


### PR DESCRIPTION
Testing with TIFF files and the `AD_TIFF` file handler revealed issues with how data was being shaped.  Databroker v2 expects the shape to be `(num_images, y, x)`, and in cases where `num_images = 1` this dimension would be squeezed out of the dataset.  

Thanks to @danielballan for debugging this with me 