### PR TITLE
Do not close() when gc-ed.

### DIFF
--- a/area_detector_handlers/__init__.py
+++ b/area_detector_handlers/__init__.py
@@ -20,10 +20,29 @@ class HandlerBase:
         self.close()
 
     def close(self):
+        """
+        Subclasses should clean up all resources here.
+
+        This includes open files, network connections, and internal memory allocations.
+        """
         pass
 
     def __del__(self):
-        try:
-            self.close()
-        except Exception:
-            pass
+        # Intentionally do NOT close() on __del__.
+
+        # It is common for handlers to go out of scope and be garbage collected
+        # wnile there are still objects wrapping the handlers' open file(s)
+        # with deferred I/O yet to be performed. If we close the files as part
+        # of handler garbage collection, the deferred I/O will fail when it
+        # tries to operate on a closed file.
+
+        # For example, HDF5 handlers return dask.arrays wrapping h5py Datasets.
+        # The corresponding h5py.File must still be open when those dask arrays
+        # are computed. It is not unusual for a BlueskyRun and its handlers to
+        # go out of scope and be garbage collected before the arrays are
+        # computed.
+
+        # Explicitly closing the handler with close() or using it as a context
+        # is a different story. In that case the calling code is declaring that
+        # it is explictly done with any associated I/O.
+        pass

--- a/area_detector_handlers/_xspress3.py
+++ b/area_detector_handlers/_xspress3.py
@@ -77,12 +77,6 @@ class Xspress3HDF5Handler(HandlerBase):
             logger.warning("Unable to load the full dataset into memory", exc_info=ex)
             self._dataset = hdf_dataset
 
-    def __del__(self):
-        try:
-            self.close()
-        except Exception as ex:
-            logger.warning("Failed to close file", exc_info=ex)
-
     def __call__(self, frame=None, channel=None):
         # Don't read out the dataset until it is requested for the first time.
         self._get_dataset()


### PR DESCRIPTION
See lengthy code comment for justification.

Here is the motivating example: the `BlueskyRun` goes out of scope, so it and its internal `Filler` and handlers are gc-ed, but we still have live `dask.array`s wrapping those files. The files must not be closed under them. The files will be released by the garbage collector when the dask arrays are computed.

```py
        for stream_name in reversed(stream_names):
            ds = run[stream_name].to_dask()
            namespace.update({column: ds[column] for column in ds})
            namespace.update({column: ds[column] for column in ds.coords})
```

[Source](https://github.com/bluesky/bluesky-widgets/blob/f9b02deb876503176b8f593638a264d9e9b81099/bluesky_widgets/models/utils.py#L97-L100)

We have seen issues with files getting closed under us too soon before. I recall something similar during the Pilot CSX visit in January. Maybe something like this was the cause. cc @ihumphrey @ronpandolfi @HarinarayanKrishnan @dylanmcreynolds 